### PR TITLE
Add Docker-Compose file to start Server & Client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2.3'
+
+services:
+  carla-server:
+    build: ./server/
+    ports:
+        - 2000-2002:2000-2002
+    image: carla-server
+
+  carla-client:
+    build: ./client/
+    runtime: nvidia
+    network_mode: 'host'
+    volumes:
+        - .:/app
+    image: carla-client
+    depends_on:
+        - carla-server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,3 +9,4 @@ COPY --chown=carla ./CarlaSettings.ini .
 
 USER carla
 
+CMD ./CarlaUE4.sh /Game/Maps/Town01 -carla-server -benchmark -fps=15 -windowed -ResX=800 -ResY=600


### PR DESCRIPTION
Docker Compose effortlessly runs both Carla Server and Client. The
server starts with standard settings on port 2000-2002. For the client
side, a terminal running bash starts so that the user can input the
command they want to start the training process with the desired
arguments.
Docker-compose only works for standard server:
Town01, benchmark, fps=15, windowed, ResX=800, ResY=600